### PR TITLE
Added note on stat execution stat as well as updated dependancy list.

### DIFF
--- a/docs/src/Configuration/Stats.md
+++ b/docs/src/Configuration/Stats.md
@@ -2,7 +2,7 @@
 
 **File:** `config.toml`
 
-> **NOTE:** The execution time of Catnip will increase when enabling the package manager stat.
+> **NOTE:** The execution time of Catnip will increase when enabling the package manager, weather and GPU stats. Catnip **cannot** in any way decrease the time for the weather and package manager stats. This is due to the fact that the package manager stat is dependent on the speed of your distro's package manager, and the weather stat is dependent on your internet speed as well as the response time of the weather info website, [wttr.in](https://github.com/chubin/wttr.in).
 
 ## Icons
 You can change the icon of any `stat` inside of the `[stats]` section.

--- a/docs/src/Setup/Installation.md
+++ b/docs/src/Setup/Installation.md
@@ -11,10 +11,13 @@ $ yay -S catnip-git
 **1.** Install all dependencies:
 - **Required:**
     - Build dependencies: `nim, gzip`
-    - Runtime dependencies: `pcre, usbutils`
+    - Runtime dependencies: `pcre`
+
 - **Optional:**
     - `figlet`: For figlet logos mode.
     - `viu`: For image mode.
+    - `curl`: For weather stat.
+    - `usbutils`: For multi-disk support.
 
 **2.** Clone the official catnip repository:
 ```shell
@@ -33,4 +36,4 @@ nim install
 This will automatically build catnip and install it inside of your `/usr/local/bin` folder.
 
 > **IMPORTANT**:
-> For the default icons to work, make sure you set a [NerdFont](https://www.nerdfonts.com/) as you terminal font.
+> For the default icons to work, make sure you set a [NerdFont](https://www.nerdfonts.com/) as you terminal font. In addition, for the weather module to work, you will need a font that supports emojis.

--- a/docs/src/Setup/Installation.md
+++ b/docs/src/Setup/Installation.md
@@ -11,13 +11,13 @@ $ yay -S catnip-git
 **1.** Install all dependencies:
 - **Required:**
     - Build dependencies: `nim, gzip`
-    - Runtime dependencies: `pcre`
+    - Runtime dependencies: `pcre`, `usbutils`
 
 - **Optional:**
     - `figlet`: For figlet logos mode.
     - `viu`: For image mode.
     - `curl`: For weather stat.
-    - `usbutils`: For multi-disk support.
+    - `pciutils`: For GPU stat.
 
 **2.** Clone the official catnip repository:
 ```shell


### PR DESCRIPTION
### Is your pull request linked to an existing issue?
No.

### What is your pull request about?:
I added expanded the note on stat execution time as I've noticed that the weather and GPU stat both increase the stat time in addition to the package count stat.

I'm pretty sure `usbutils` is not a required dependancy as I can run Catnip normally without installing it.

The weather stat requires the `cURL` package.

### Any other disclosures/notices/things to add?
No.